### PR TITLE
Changed role directory to match README

### DIFF
--- a/tests/playbook.yml.j2
+++ b/tests/playbook.yml.j2
@@ -5,4 +5,4 @@
   gather_facts: yes
 
   roles:
-    - ../../{{ role_name }}
+    - ../../ansible-role-{{ role_name }}


### PR DESCRIPTION
##### SUMMARY
README contains instruction to `mv NEWROLE ansible-role-NEWROLE`
I forgot this when testing and changed the code instead of following the instructions. Undone.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### ANSIBLE VERSION
```
ansible [core 2.12.2]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/nick/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /home/nick/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.8.10 (default, Nov 26 2021, 20:14:08) [GCC 9.3.0]
  jinja version = 2.10.1
  libyaml = True
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
